### PR TITLE
Fixed issue #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v1.1.0, 2023-11-21
+## v1.1.0, 2024-01-17
 
 - Solver and integrator improvements
 - Debug mode bug fixes
@@ -20,6 +20,7 @@
 
 - Fixed a number of bugs in the code where divide-by-zero FPEs would be raised in debug mode. Some still remain.
 - Fixed a bug with gfortran-11.4 which caused bound changes in an MPI buffer
+- Some tests were failing when run on an M2 Mac due to FPE differences. This has been fixed. 
 
 ## v1.0.0, 2023-06-21
 

--- a/tests/test_basic_support/test_interpolation.pf
+++ b/tests/test_basic_support/test_interpolation.pf
@@ -151,7 +151,7 @@ subroutine test_interpnd
     @assertEqual(testNDInterp3%getFirstDataIndicesForDim(1),[1,5])
     @assertEqual(testNDInterp3%getFirstDataIndicesForDim(2),[3,1])
     @assertEqual(testNDInterp3%getFirstDataIndicesForDim(3),[4,1])
-    @assertEqual(testNDInterp3%interpolate(test3DData),real([4051.0d0,599.8d0],kind=rk))
+    @assertEqual(testNDInterp3%interpolate(test3DData),real([4051.0d0,599.8d0],kind=rk),tolerance=1e-12)
 end subroutine test_interpnd
 
 @test

--- a/tests/test_kinetic_models/test_kinetic_models.pf
+++ b/tests/test_kinetic_models/test_kinetic_models.pf
@@ -409,7 +409,7 @@ contains
 
         checkVec(1) = 0
         checkVec(5) = 0
-        @assertEqual(testVec,checkVec,tolerance=1.d-14)
+        @assertEqual(testVec,checkVec,tolerance=1.d-13)
         
     end subroutine test_moment_stencil
 

--- a/tests/test_kinetic_terms/test_moment_term.pf
+++ b/tests/test_kinetic_terms/test_moment_term.pf
@@ -108,7 +108,7 @@ contains
 
         checkVec(1) = 0
         checkVec(5) = 0
-        @assertEqual(testVec,checkVec,tolerance=1.d-14)
+        @assertEqual(testVec,checkVec,tolerance=1.d-13)
         
     end subroutine test_m_term
 


### PR DESCRIPTION
The compiler optimisations that are made when compiling on an M2 Mac cause there to be a discrepancy in the floating point errors. By changing the tolerances of the failing tests this is fixed