### PR TITLE
Fixed Dockerfile for Apple Silicon (M4 Pro)

### DIFF
--- a/docker/Dockerfile_mac.txt
+++ b/docker/Dockerfile_mac.txt
@@ -14,7 +14,7 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt update \
         && apt install -y \
         gfortran-11 \
-        g++-11 \ 
+        g++-11 \
         libblas-dev \
         liblapack-dev \
         m4 \

--- a/docker/Dockerfile_mac.txt
+++ b/docker/Dockerfile_mac.txt
@@ -1,7 +1,7 @@
 FROM --platform=linux/arm64 ubuntu:latest
 LABEL maintainer="vera.oberhauser@ukaea.uk"
-LABEL version="1.2.1"
-LABEL description="Docker container for ReMKiT1D CI"
+LABEL version="1.3.0"
+LABEL description="Docker container for ReMKiT1D for ARM64"
 
 # Disable Prompt During Packages Installation
 ARG DEBIAN_FRONTEND=noninteractive
@@ -14,18 +14,16 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt update \
         && apt install -y \
         gfortran-11 \
-        g++-11 \
-        python3 \
-        python3-dev \
-        pip \
+        g++-11 \ 
         libblas-dev \
-        libhdf5-dev \
         liblapack-dev \
         m4 \
         wget \
         git \
-        gcovr \ 
+        gcovr \
         gcc-arm-linux-gnueabihf \
+        python3 \
+        python3-dev \
         build-essential \
         pkg-config
 
@@ -57,7 +55,10 @@ RUN mkdir mpich-install
 WORKDIR /home/mpich-3.4.2
 
 # ReMKiT1D Requires gfortran-11, gcc-11 and g++-11. CMake Installs the Package to the mpich-install Folder
-RUN ./configure CC=gcc-11 CXX=g++-11 FC=gfortran-11 --prefix=/home/mpich-install  FFLAGS=-fallow-argument-mismatch --with-device=ch3
+RUN ./configure CC=gcc-11 CXX=g++-11 FC=gfortran-11 \
+    --prefix=/home/mpich-install \
+    FFLAGS="-fallow-argument-mismatch" \
+    --with-device=ch3
 
 RUN make
 RUN make install
@@ -69,19 +70,27 @@ ENV PATH=/home/mpich-install/bin:$PATH
 # PETSc-3.17 is the Newest Release that has been Tested on ReMKiT1D (3.18 not Compatible)
 RUN git clone -b release-3.17 https://gitlab.com/petsc/petsc.git petsc
 
-WORKDIR petsc/
+WORKDIR /home/petsc
 
 #PETSc Requires MPI and PETSc is Told Where MPI (mpich-4.2.2) is Installed
-RUN ./configure --with-mpi-dir=/home/mpich-install --download-hypre=1 --download-fblaslapack=1 --with-debugging=0 COPTFLAGS=-O3 CXXOPTFLAGS=-O3 FOPTFLAGS=-O3
+# ARM64 optimization flags for Apple Silicon
+RUN ./configure \
+    --with-mpi-dir=/home/mpich-install \
+    --download-hypre=1 \
+    --download-fblaslapack=1 \
+    --with-debugging=0 \
+    COPTFLAGS="-O3 -mcpu=native" \
+    CXXOPTFLAGS="-O3 -mcpu=native"\
+    FOPTFLAGS="-O3 -mcpu=native"
 RUN make PETSC_DIR=/home/petsc PETSC_ARCH=arch-linux-c-opt all check
 
 WORKDIR /home
 
 # pFUnit-4.2.2 is Installed for the use of Unit Testing
 RUN git clone -b v4.2.2 https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
-WORKDIR pFUnit
-RUN mkdir build
-WORKDIR build
+WORKDIR /home/pFUnit
+RUN mkdir -p /home/pFUnit/build
+WORKDIR /home/pFUnit/build
 
 # ReMKiT1D Requires gfortran-11, gcc-11 and g++-11. CMake Installs the Package to the 'installs' Folder
 RUN cmake .. -DSKIP_OPENMP=yes -DCMAKE_Fortran_COMPILER=gfortran-11 -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_INSTALL_PREFIX=/home/installs/pFUnit
@@ -91,9 +100,9 @@ WORKDIR /home
 # ReMKiT1D is Currently using json-fortran-8.2.5
 RUN git clone -b 8.2.5 https://github.com/jacobwilliams/json-fortran.git
 
-WORKDIR json-fortran
-RUN mkdir build
-WORKDIR build
+WORKDIR /home/json-fortran
+RUN mkdir -p /home/json-fortran/build
+WORKDIR /home/json-fortran/build
 
 # ReMKiT1D Requires gfortran-11, gcc-11 and g++-11. CMake Installs the Package to the 'installs' Folder
 RUN cmake .. -DCMAKE_Fortran_COMPILER=gfortran-11 -DCMAKE_INSTALL_PREFIX=/home/installs/json-fortran -DSKIP_DOC_GEN=TRUE
@@ -102,11 +111,18 @@ RUN make install
 WORKDIR /home
 
 # HDF5 is Required and HDF5-1.13.0 is used within the main.yml Workflow Script
-RUN git clone -b hdf5-1_13_0 https://github.com/HDFGroup/hdf5.git
+# Use a shallow clone and configure git to be more tolerant of curl/TLS issues
+# This reduces the data transferred and avoids common fetch-pack disconnects
+RUN git config --global http.version HTTP/1.1 && \
+    git config --global http.postBuffer 524288000 && \
+    git clone --depth 1 --branch hdf5-1_13_0 --single-branch https://github.com/HDFGroup/hdf5.git || \
+    (echo "git clone failed, attempting to download hdf5 release tarball" && \
+     wget -O hdf5.tar.gz https://github.com/HDFGroup/hdf5/archive/refs/heads/hdf5-1_13_0.tar.gz && \
+     mkdir hdf5 && tar -xzf hdf5.tar.gz --strip-components=1 -C hdf5)
 
-WORKDIR hdf5
-RUN mkdir build
-WORKDIR build
+WORKDIR /home/hdf5
+RUN mkdir -p /home/hdf5/build
+WORKDIR /home/hdf5/build
 
 # ReMKiT1D Requires gfortran-11, gcc-11 and g++-11. CMake Installs the Package to the 'installs' Folder
 RUN cmake .. -DCMAKE_Fortran_COMPILER=gfortran-11 -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DHDF5_BUILD_FORTRAN=ON -DCMAKE_INSTALL_PREFIX=/home/installs/hdf5
@@ -114,29 +130,31 @@ RUN cmake .. -DCMAKE_Fortran_COMPILER=gfortran-11 -DCMAKE_C_COMPILER=gcc-11 -DCM
 RUN make install
 WORKDIR /home
 
+
 # ReMKiT1D v1.2.0+ requires sundials 
 RUN git clone -b v7.2.1 https://github.com/LLNL/sundials.git
-WORKDIR sundials
-RUN mkdir build
-WORKDIR build
+WORKDIR /home/sundials
+RUN mkdir -p /home/sundials/build
+WORKDIR /home/sundials/build
 
-RUN cmake .. -DENABLE_MPI=ON -DCMAKE_INSTALL_PREFIX=/home/installs/sundials -DENABLE_LAPACK=ON -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DCMAKE_C_COMPILER=gcc-11
+RUN cmake .. -DENABLE_MPI=ON -DCMAKE_INSTALL_PREFIX=/home/installs/sundials -DENABLE_LAPACK=ON -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DCMAKE_C_COMPILER=gcc-11 
 RUN make
 RUN make install
 
 WORKDIR /home
 
 RUN echo LD_LIBRARY_PATH=/home/mpich-install/lib:$LD_LIBRARY_PATH
+RUN echo LD_LIBRARY_PATH=/home/sundials/lib:$LD_LIBRARY_PATH
+
 
 # Add the PATH to assist CMake and Make Find the Required Compilation Files
 ENV PFUNIT_DIR=/home/installs/pFUnit
 ENV PETSC_DIR=/home/petsc
 ENV PETSC_ARCH=arch-linux-c-opt
+ENV PATH=$PATH:/home/installs
 ENV PATH=$PATH:/home/installs/petsc
 ENV PATH=$PATH:/home/installs/hdf5
 ENV PATH=$PATH:/home/installs/json-fortran/jsonfortran-gnu-8.2.5
 ENV PATH=$PATH:/home/mpich-install/bin:$PATH
 ENV PATH=$PATH:/home/installs/sundials
-ENV LD_LIBRARY_PATH=/home/mpich-install/lib:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH=/home/sundials/lib:$LD_LIBRARY_PATH
 ENV SUNDIALS_DIR=/home/installs/sundials/lib/cmake/sundials

--- a/docker/Dockerfile_mac.txt
+++ b/docker/Dockerfile_mac.txt
@@ -80,7 +80,7 @@ RUN ./configure \
     --download-fblaslapack=1 \
     --with-debugging=0 \
     COPTFLAGS="-O3 -mcpu=native" \
-    CXXOPTFLAGS="-O3 -mcpu=native"\
+    CXXOPTFLAGS="-O3 -mcpu=native" \
     FOPTFLAGS="-O3 -mcpu=native"
 RUN make PETSC_DIR=/home/petsc PETSC_ARCH=arch-linux-c-opt all check
 

--- a/docker/Dockerfile_mac.txt
+++ b/docker/Dockerfile_mac.txt
@@ -137,7 +137,7 @@ WORKDIR /home/sundials
 RUN mkdir -p /home/sundials/build
 WORKDIR /home/sundials/build
 
-RUN cmake .. -DENABLE_MPI=ON -DCMAKE_INSTALL_PREFIX=/home/installs/sundials -DENABLE_LAPACK=ON -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DCMAKE_C_COMPILER=gcc-11 
+RUN cmake .. -DENABLE_MPI=ON -DCMAKE_INSTALL_PREFIX=/home/installs/sundials -DENABLE_LAPACK=ON -DBUILD_FORTRAN_MODULE_INTERFACE=ON -DCMAKE_C_COMPILER=gcc-11
 RUN make
 RUN make install
 


### PR DESCRIPTION
Fixes issue #34 

**Changes:**
- Set ARM64-specific optimisation flags
- Implemented a shallow clone of HDF5 to reduce data transfer and avoid `fetch-pack` disconnects during the build process

**Testing:**
- Successfully built and tested on Apple M4 Pro (macOS 26.1)
- All unit tests passed for ReMKiT1D v1.3.0